### PR TITLE
add MCP server badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,10 @@
 
 An MCP (Model Context Protocol) server for controlling Wyze smart home devices using the wyze-sdk library.
 
+<a href="https://glama.ai/mcp/servers/@aldilaff/mcp-wyze-server">
+  <img width="380" height="200" src="https://glama.ai/mcp/servers/@aldilaff/mcp-wyze-server/badge" alt="Wyze Server MCP server" />
+</a>
+
 ## Overview
 
 This MCP server provides a comprehensive interface for interacting with Wyze devices through AI assistants like Claude. It supports authentication, device discovery, device control, and group management for various Wyze smart home products.


### PR DESCRIPTION
This PR adds a badge for the [MCP Wyze Server](https://glama.ai/mcp/servers/@aldilaff/mcp-wyze-server) server listing in Glama MCP server directory.

<a href="https://glama.ai/mcp/servers/@aldilaff/mcp-wyze-server">
  <img width="380" height="200" src="https://glama.ai/mcp/servers/@aldilaff/mcp-wyze-server/badge" alt="Wyze Server MCP server" />
</a>

Glama performs regular codebase and documentation checks to:

* Confirm that the MCP server is working as expected
* Confirm that there are no obvious security issues with dependencies of the server
* Extract server characteristics such as tools, resources, prompts, and required parameters.

This badge helps your users to quickly assess that the MCP server is safe, server capabilities, and instructions for installing the server.